### PR TITLE
publish drools and jbpm to a site from which JBoss Central can get it

### DIFF
--- a/droolsjbpm-uber-distribution/pom.xml
+++ b/droolsjbpm-uber-distribution/pom.xml
@@ -37,6 +37,43 @@
           <appendAssemblyId>false</appendAssemblyId> 
         </configuration>
       </plugin>
+
+<plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <id>install</id>
+            <phase>install</phase>
+            <configuration>
+              <quiet>true</quiet>
+              <tasks>
+                <script language="javascript">
+                  <![CDATA[
+                    property = project.setProperty("p2.timestamp.now",Math.floor((new Date()).getTime()/1000));
+                  ]]>
+                </script>
+                <echo>Changing p2.timestamp in latest/composite*.xml files to ${p2.timestamp.now}</echo>
+                <replaceregexp match="@@p2.timestamp.now@@" replace="${p2.timestamp.now}000">
+                  <fileset dir="${basedir}/target">
+                    <include name="**/droolsjbpm-uber-distribution*/download_jboss_org/latest/composite*.xml"/>
+                  </fileset>
+                </replaceregexp>
+              </tasks>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
+            <version>1.8.2</version>
+          </dependency>
+        </dependencies>
+      </plugin>      
     </plugins>
   </build>
 

--- a/droolsjbpm-uber-distribution/src/main/assembly/assembly-droolsjbpm-uber.xml
+++ b/droolsjbpm-uber-distribution/src/main/assembly/assembly-droolsjbpm-uber.xml
@@ -14,6 +14,15 @@
       <directory>src/main/assembly/filtered-resources</directory>
       <filtered>true</filtered>
       <outputDirectory/>
+        <excludes>
+          <exclude>latest</exclude>
+          <exclude>latest/**</exclude>
+        </excludes>
+    </fileSet>
+    <fileSet>
+      <directory>src/main/assembly/filtered-resources/latest</directory>
+      <filtered>true</filtered>
+      <outputDirectory>download_jboss_org/latest</outputDirectory>
     </fileSet>
   </fileSets>
 
@@ -26,9 +35,20 @@
         <include>org.drools:guvnor-distribution:zip</include>
         <include>org.drools:droolsjbpm-tools-distribution:zip</include>
         <include>org.drools:drools-osgi-bundles-distribution:zip</include>
+        <include>org.drools:org.drools.updatesite:zip</include>
       </includes>
       <unpack>false</unpack>
       <outputDirectory>download_jboss_org/${project.version}</outputDirectory>
+      <useStrictFiltering>true</useStrictFiltering>
+    </dependencySet>
+
+    <!-- unpacked update site -->
+    <dependencySet>
+      <includes>
+        <include>org.drools:org.drools.updatesite:zip</include>
+      </includes>
+      <outputDirectory>download_jboss_org/${project.version}/org.drools.updatesite</outputDirectory>
+      <unpack>true</unpack>
       <useStrictFiltering>true</useStrictFiltering>
     </dependencySet>
 

--- a/droolsjbpm-uber-distribution/src/main/assembly/filtered-resources/latest/compositeArtifacts.xml
+++ b/droolsjbpm-uber-distribution/src/main/assembly/filtered-resources/latest/compositeArtifacts.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?compositeArtifactRepository version='1.0.0'?>
+<repository name='Drools and jBPM plugins for Eclipse' type='org.eclipse.equinox.internal.p2.artifact.repository.CompositeArtifactRepository' version='1.0.0'>
+<properties size='2'>
+<property name='p2.compressed' value='true'/>
+<property name='p2.timestamp' value='@@p2.timestamp.now@@'/>
+</properties>
+<children size='1'>
+<child location='../${project.version}/org.drools.updatesite/'/>
+</children>     
+</repository>

--- a/droolsjbpm-uber-distribution/src/main/assembly/filtered-resources/latest/compositeContent.xml
+++ b/droolsjbpm-uber-distribution/src/main/assembly/filtered-resources/latest/compositeContent.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?compositeMetadataRepository version='1.0.0'?>
+<repository name='Drools and jBPM plugins for Eclipse' type='org.eclipse.equinox.internal.p2.metadata.repository.CompositeMetadataRepository' version='1.0.0'>
+<properties size='2'>
+<property name='p2.compressed' value='true'/>
+<property name='p2.timestamp' value='@@p2.timestamp.now@@'/>
+</properties>
+<children size='1'>
+<child location='../${project.version}/org.drools.updatesite/'/>
+</children>
+</repository>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBRULES-3470 provide mechanism to publish: update site zip, update site (unpacked), and a latest/ folder which includes composite site metadata pointing at the latest actual release (unpacked site)
